### PR TITLE
Feed URL on front page

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -53,7 +53,7 @@
     {% block footer %}
     <!-- footer start -->
     <footer class="site-footer">
-      <a class="subscribe" href="{{ home.url }}/blog.rss"> <span class="tooltip"> <i class="fa fa-rss"></i> Subscribe!</span></a>
+      <a class="subscribe" href="{{ base_url_relative }}/blog.rss"> <span class="tooltip"> <i class="fa fa-rss"></i> Subscribe!</span></a>
         <div class="inner">
              <section class="copyright">All content copyright <a href="mailto:{{ site.email}}">{{ site.name }}</a> &copy; {{ "now"|date('Y') }} &bull; All rights reserved.</section>
              <section class="poweredby">Made with <a href="http://getgrav.org"> Grav</a></section>


### PR DESCRIPTION
For me the path of the RSS URL did not work. Works again for me using `{{ base_url_relative }}`.
