### PR TITLE
Fixed logo link to use home URL

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -35,7 +35,7 @@
 {% set home = pages.find(config.system.home.alias) %}
 
     {% block header %}
-        <a href="{{ base_url_relative }}" class="logo-readium"><span class="logo" style="background-image: url({{ base_url_relative }}{{ site.logo }})"></span></a>
+        <a href="{{ home.url }}" class="logo-readium"><span class="logo" style="background-image: url({{ base_url_relative }}{{ site.logo }})"></span></a>
     {% endblock %}
 
     <!-- content start -->


### PR DESCRIPTION
Since `base_url_relative` returns an empty string if you're not in a sub directory it seemed more reasonable to me that the logo itself would go to the main URL. Using `base_url_relative` would cause the user to go to the same page they're at since it would be blank. So I mimicked what you're doing on the RSS link and used `home.url` instead.
