### PR TITLE
Multilanguage support

### DIFF
--- a/templates/default.html.twig
+++ b/templates/default.html.twig
@@ -15,7 +15,7 @@
 
     <header class="blog-header">
         {% if site.logo %}
-          <a class="blog-logo" href="{{ base_url_relative}}" style="background-image: url({{ base_url_relative }}{{ site.logo }})">{{ site.title }}</a>
+          <a class="blog-logo" href="{{ base_url_relative}}" style="background-image: url({{ uri.rootUrl() }}{{ site.logo }})">{{ site.title }}</a>
         {% endif %}
         <h1 class="blog-title">{{ site.title }}</h1>
         <h2 class="blog-description">{{ site.description }}</h2>

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -35,7 +35,7 @@
 {% set home = pages.find(config.system.home.alias) %}
 
     {% block header %}
-        <a href="{{ base_url_relative }}" class="logo-readium"><span class="logo" style="background-image: url({{ base_url_relative }}{{ site.logo }})"></span></a>
+        <a href="{{ base_url_relative }}" class="logo-readium"><span class="logo" style="background-image: url({{ uri.rootUrl() }}{{ site.logo }})"></span></a>
     {% endblock %}
 
     <!-- content start -->

--- a/templates/partials/postmeta.html.twig
+++ b/templates/partials/postmeta.html.twig
@@ -6,7 +6,7 @@
     {% endif %}
     {% if page.template == 'post' %}
     <div class="cf post-meta-text">
-        <div class="author-image" style="background-image: url({{ base_url }}{{ site.author.image }})">Blog Logo</div>
+        <div class="author-image" style="background-image: url({{ uri.rootUrl() }}{{ site.author.image }})">Blog Logo</div>
         <h4 class="author-name" itemprop="author" itemscope itemtype="http://schema.org/Person">{{ site.author.name }}</h4>
         on
         <time datetime="{{ page.date | date(site.date_short) }}">{{ page.date | date(site.date_short) }}</time>

--- a/templates/post.html.twig
+++ b/templates/post.html.twig
@@ -49,7 +49,7 @@
           <div class="isLeft">
             <h5 class="index-headline featured"><span>Written by</span></h5>
             <section class="author">
-              <div class="author-image" style="background-image: url({{ base_url }}{{site.author.image}})">Blog Logo</div>
+              <div class="author-image" style="background-image: url({{ uri.rootUrl() }}{{site.author.image}})">Blog Logo</div>
               <h4>{{ site.author.name }}</h4>
               <p class="bio">{{site.author.bio}}</p>
               <hr>


### PR DESCRIPTION
When you enable multilanguage support on Grav using the languages key in the configuration. Like

```
languages:
  supported:
    - es
    - en
```

in the user/config/system.yaml file. The logo and the author image dissapears because it's trying to get the image from a wrong url i.e. website.url/en/images/logo.jpg and the correct one must be website.url/images/logo.jpg

This commits fix the thing and I guess it adds multilanguage support to the theme.

Regards !
