### PR TITLE
Escaping '#' in jQuery selection for click event

### DIFF
--- a/templates/partials/javascripts.html.twig
+++ b/templates/partials/javascripts.html.twig
@@ -25,7 +25,7 @@
     var height = $('.article-image').height();
     $('.post-content').css('padding-top', height + 'px');
 
-    $('a[href*=#]:not([href=#])').click(function() {
+    $('a[href*=\\#]:not([href=\\#])').click(function() {
       if (location.pathname.replace(/^\//,'') == this.pathname.replace(/^\//,'')
        && location.hostname == this.hostname) {
         var target = $(this.hash);


### PR DESCRIPTION
a[href*=#]:not([href=#]) is incorrect and throws error. # is a special character and must be escaped.
For more info: https://github.com/jquery/jquery/issues/2885