### PR TITLE
Move deferred javascript assets

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -63,9 +63,5 @@
     {% endblock %}
 
     {% include 'partials/javascripts.html.twig' %}
-    {% block bottom %}
-        {{ assets.js()|raw }}
-        {{ assets.js('bottom')|raw }}
-    {% endblock %}
 </body>
 </html>

--- a/templates/partials/javascripts.html.twig
+++ b/templates/partials/javascripts.html.twig
@@ -2,6 +2,10 @@
 {% do assets.addJs('theme://js/jquery.fitvids.js') %}
 {% do assets.addJs('theme://js/index.js') %}
 {% do assets.addJs('theme://js/readingTime.min.js') %}
+{% block bottom %}
+  {{ assets.js()|raw }}
+  {{ assets.js('bottom')|raw }}
+{% endblock %}
 
 <script>
 (function ($) {


### PR DESCRIPTION
With the changes made in the [version 1.4](https://github.com/getgrav/grav-theme-mediator/commit/35c8fc2f9d30b4a92fbe4cab658ff22ee19c7481) (related to [deffered assets](https://getgrav.org/blog/important-theme-updates)), I noticed that some specific features related to `.post-image-image` and `.teaserimage-image` classes don't work properly.

Moving the bottom block from `base.html.twig` into `javascripts.html.twig` template seems to reorder rightly assets in order to run script which needed by these classes.