### PR TITLE
Fix ellipsis on landing page posts

### DIFF
--- a/templates/partials/article.html.twig
+++ b/templates/partials/article.html.twig
@@ -8,7 +8,7 @@
             {% endif %}
         </header>
         <section class="post-excerpt" itemprop="description">
-            <p>{{ post.content | striptags | truncate(200) }}</p>
+            <p>{{ post.content | striptags | truncate(200, true, '…') | raw }}</p>
         </section>
         <div class="post-meta">
             <time datetime="{{ post.date | date(site.date_long) }}">{{ post.date | date(site.date_long) }}</time>


### PR DESCRIPTION
This small patch addresses a visualization problem with post ellipsis on the main landing page. 

Using the Skeleton, I found that the ellipsis on the blog posts of the landing page do not display the ellipsis `…` character correctly, leading to each of the posts being rendered with the text `&hellip;` (textual HTML representation of the ellipsis).

Using the extended `truncate(...)` syntax together with `raw` fixed the problem for me